### PR TITLE
Update hook-nltk.py to overlook unused data dirs

### DIFF
--- a/PyInstaller/hooks/hook-nltk.py
+++ b/PyInstaller/hooks/hook-nltk.py
@@ -9,7 +9,7 @@
 
 
 # hook for nltk
-import nltk
+import nltk, os
 from PyInstaller.utils.hooks import collect_data_files
 
 # add datas for nltk
@@ -17,7 +17,8 @@ datas = collect_data_files('nltk', False)
 
 # loop through the data directories and add them
 for p in nltk.data.path:
-    datas.append((p, "nltk_data"))
+    if os.path.exists(p):
+        datas.append((p, "nltk_data"))
 
 # nltk.chunk.named_entity should be included
 hiddenimports = ["nltk.chunk.named_entity"]


### PR DESCRIPTION
Fixes the hook error attempting to load unused data directories from nltk. Addresses https://github.com/nltk/nltk/issues/2159 and https://github.com/pyinstaller/pyinstaller/issues/1099. 

edit: The error message is 
$ pyinstaller my_script_with_nltk.py --onefile --windowed
...
14535 INFO: Loading module hook "hook-nltk.py"...
Unable to find "/usr/share/nltk_data" when adding binary and data files.
(with varying path directories depending on your setup)